### PR TITLE
fix: cache directory creation and error handling

### DIFF
--- a/actions/action.go
+++ b/actions/action.go
@@ -1,9 +1,14 @@
 package actions
 
 import (
-	"github.com/mbaraa/eloi/db"
+	"errors"
+	"fmt"
 	"io"
+
+	"github.com/mbaraa/eloi/db"
 )
+
+var ErrUnknownActionType = errors.New("unknown action type")
 
 // Action is an operation that can be used when running the program
 // any implementation will be called directly from the command line
@@ -27,20 +32,20 @@ const (
 	EnableRepoActionType
 )
 
-func GetActionFactory(at ActionType) Action {
+func GetActionFactory(at ActionType) (Action, error) {
 	ebuildDB, err := db.GetEbuildDB()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("action.GetActionFactory: couldn't get ebuild DB: %w", err)
 	}
 
 	switch at {
 	case DownloadReposCacheActionType:
-		return new(DownloadReposCacheAction)
+		return new(DownloadReposCacheAction), nil
 	case EbuildSearchActionType:
-		return NewEbuildSearchAction(ebuildDB)
+		return NewEbuildSearchAction(ebuildDB), nil
 	case EnableRepoActionType:
-		return new(EnableRepoAction)
+		return new(EnableRepoAction), nil
 	default:
-		return nil
+		return nil, fmt.Errorf("%d: %w", at, ErrUnknownActionType)
 	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -45,7 +45,11 @@ func Start() {
 }
 
 func runWithGivenArgs(actionType actions.ActionType, arg string) {
-	action := actions.GetActionFactory(actionType)
+	action, err := actions.GetActionFactory(actionType)
+
+	if err != nil {
+		utils.Exit(fmt.Errorf("cmd.runWithGivenArgs: %w", err).Error())
+	}
 	if action.NeedsRoot() {
 		utils.AssertRoot()
 	}
@@ -55,7 +59,7 @@ func runWithGivenArgs(actionType actions.ActionType, arg string) {
 		utils.ExitWhite(usageStr)
 	}
 
-	err := action.Exec(os.Stdout, arg)
+	err = action.Exec(os.Stdout, arg)
 	if err != nil {
 		utils.Exit(err.Error())
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/mbaraa/eloi/globals"
@@ -16,8 +17,13 @@ var instance *gorm.DB = nil
 
 func GetInstance() (*gorm.DB, error) {
 	if _, err := os.Stat(globals.CacheDirectory); !os.IsExist(err) {
-		_ = os.Mkdir(globals.CacheDirectory, 0755)
+		err = os.Mkdir(globals.CacheDirectory, 0755)
+
+		if err != nil {
+			return nil, fmt.Errorf("db.GetInstance: couldn't create directory: %w", err)
+		}
 	}
+
 	if _, err := os.Stat(EloiDBPath); instance == nil || err != nil {
 		var err error
 		instance, err = gorm.Open(sqlite.Open(EloiDBPath), &gorm.Config{


### PR DESCRIPTION
This PR fixes directory creation issues when the command is not run as root and improves error handling a bit adding stack traces with fmt.Errorf()

Fixes #9 